### PR TITLE
Fix for issue when used with adapt-pageIncompletePrompt

### DIFF
--- a/js/adapt-quicknav.js
+++ b/js/adapt-quicknav.js
@@ -23,8 +23,6 @@ define(function(require) {
 		menuStructure: {},
 		onRootClicked: function() {
 			Backbone.history.navigate("#/",{trigger:true, "replace": true});
-			this.state.currentMenu = undefined;
-			this.state.currentPage = undefined;
 		},
 		onPreviousClicked:function() {
 			var menus = undefined;


### PR DESCRIPTION
Using root navigation on incomplete page will invoke PIP. If user cancels navigation quicknav will experience errors on subsequent navgiation attempts (e.g. via Next button) because state properties have been cleared. I see no justification for clearing these properties so propose simply removing them.