### PR TITLE
Fix for #49. If `_order` is the same, use the `index` instead to keep…

### DIFF
--- a/js/model.js
+++ b/js/model.js
@@ -99,7 +99,7 @@ define([
             }
 
             data.sort(function(a, b) {
-                return a._order - b._order;
+                return a._order - b._order || a.index - b.index;
             });
             
             data.forEach(function(item, index) {


### PR DESCRIPTION
… stable.